### PR TITLE
Fix jobs

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -10,6 +10,12 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
     - uses: actions/checkout@v2
+    - name: Install and cache PowerShell modules
+      id: psmodulecache
+      uses: potatoqualitee/psmodulecache@v4.5
+      with:
+        modules-to-cache: Pester:5.3.3, psake:4.9.0, BuildHelpers:2.0.16, PowerShellBuild:0.6.1, PSScriptAnalyzer:1.19.1
+        shell: pwsh
     - name: Test
       shell: pwsh
       run: ./build.ps1 -Task Test -Bootstrap

--- a/.github/workflows/Mkdocs.yaml
+++ b/.github/workflows/Mkdocs.yaml
@@ -12,7 +12,22 @@ jobs:
       - name: Checkout main
         uses: actions/checkout@v2
 
+      - shell: pwsh
+        # Give an id to the step, so we can reference it later
+        id: check_file_changed
+        run: |
+          # Diff HEAD with the previous commit
+          $diff = git diff --name-only HEAD^ HEAD
+
+          # Check if a file under docs/ or with the .md extension has changed (added, modified, deleted)
+          $SourceDiff = $diff | Where-Object { $_ -match '^docs/' -or $_ -match '.md$' }
+          $HasDiff = $SourceDiff.Length -gt 0
+
+          # Set the output named "docs_changed"
+          Write-Host "::set-output name=docs_changed::$HasDiff"
+
       - name: Deploy docs
         uses: mhausenblas/mkdocs-deploy-gh-pages@master
+        if: steps.check_file_changed.outputs.docs_changed == 'True'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,6 +9,19 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
+      - shell: pwsh
+        # Give an id to the step, so we can reference it later
+        id: check_file_changed
+        run: |
+          # Diff HEAD with the previous commit
+          $diff = git diff --name-only HEAD^ HEAD
+
+          # Check if a file under docs/ or with the .md extension has changed (added, modified, deleted)
+          $SourceDiff = $diff | Where-Object { $_ -match '^BeneathTheCanals/' }
+          $HasDiff = $SourceDiff.Length -gt 0
+
+          # Set the output named "docs_changed"
+          Write-Host "::set-output name=docs_changed::$HasDiff"
       - name: Publish to PSGallery
         shell: pwsh
         env:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,22 +8,27 @@ jobs:
   build:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      # Get the current version
+      - uses: actions/checkout@v3
+      - name: Install BuildHelpers module
+        shell: pwsh
+        run: |
+          Set-PSRepository PSGallery -InstallationPolicy Trusted
+          Install-Module BuildHelpers -ErrorAction Stop
       - shell: pwsh
         # Give an id to the step, so we can reference it later
-        id: check_file_changed
+        id: check_if_versions_bumped
         run: |
-          # Diff HEAD with the previous commit
-          $diff = git diff --name-only HEAD^ HEAD
+          [version]$GalleryVersion = Get-NextNugetPackageVersion -Name $env:BHProjectName -ErrorAction Stop
+          [version]$GithubVersion = Get-MetaData -Path $env:BHPSModuleManifest -PropertyName ModuleVersion -ErrorAction Stop
+          $bumped = $GalleryVersion -ge $GithubVersion
 
-          # Check if a file under docs/ or with the .md extension has changed (added, modified, deleted)
-          $SourceDiff = $diff | Where-Object { $_ -match '^BeneathTheCanals/' }
-          $HasDiff = $SourceDiff.Length -gt 0
+          # Set the output named "version_bumped"
+          Write-Host "::set-output name=version_bumped::$bumped"
 
-          # Set the output named "docs_changed"
-          Write-Host "::set-output name=docs_changed::$HasDiff"
       - name: Publish to PSGallery
         shell: pwsh
+        if: steps.check_if_versions_bumped.outputs.version_bumped == 'True'
         env:
           PSGALLERY_API_KEY: ${{ secrets.PS_GALLERY_KEY }}
         run: ./build.ps1 -Task Publish -Bootstrap

--- a/requirements.psd1
+++ b/requirements.psd1
@@ -1,20 +1,20 @@
 @{
-    PSDependOptions    = @{
+    PSDependOptions = @{
         Target = 'CurrentUser'
     }
-    'Pester'           = @{
-        Version    = '5.3.0'
+    'Pester' = @{
+        Version = '5.3.3'
         Parameters = @{
             SkipPublisherCheck = $true
         }
     }
-    'psake'            = @{
+    'psake' = @{
         Version = '4.9.0'
     }
-    'BuildHelpers'     = @{
+    'BuildHelpers' = @{
         Version = '2.0.16'
     }
-    'PowerShellBuild'  = @{
+    'PowerShellBuild' = @{
         Version = '0.6.1'
     }
     'PSScriptAnalyzer' = @{


### PR DESCRIPTION
Improving all the github action jobs to run conditionally.

Publish changes will only run when landed on main AND have a module version bump.
Docs will only change when doc files or md files are updated.
CI will now cache modules to speed tests up.